### PR TITLE
pg:copy失敗からコピー先データベース変更

### DIFF
--- a/bin/pg_copy_to_metabase.sh
+++ b/bin/pg_copy_to_metabase.sh
@@ -9,7 +9,11 @@ set -o pipefail
 ##
 ## metabase で解析する postgres データベースに uuuo-web 環境のデータベースからデータをコピーするスクリプト。
 ## スクリプトは heroku Addons Schedular から実行。
-## 注意：uuuo-metabase は２基データベースを持つ。解析側（HEROKU_POSTGRESQL_BLUE_URL 現在27/4/2022）を指定すること。
+## 注意：uuuo-metabase は２基データベースを持つ。解析側データベースを環境変数TARGET_POSTGRESQL_COLORに指定すること。
+## 例）TARGET_POSTGRESQL_COLOR=HEROKU_POSTGRESQL_AMBER_URL
+## 例）SOURCE_POSTGRESQL_COLOR=uuuo-web::HEROKU_POSTGRESQL_CHARCOAL_URL
+TARGET=$TARGET_POSTGRESQL_COLOR
+SOURCE=$SOURCE_POSTGRESQL_COLOR
 ##
 ## 結果を Slack へ通知する。成功は1日1回、失敗は常に通知。
 ## WEBHOOKURL は heroku 環境変数に事前に設定する事。
@@ -38,8 +42,8 @@ trap 'err ${LINENO[0]}' ERR
 echo -e "\n`date -R`"
 echo -e "<<<<<  Copying DB from uuuo-web to uuuo-metabase. >>>>>"
 
-heroku pg:reset HEROKU_POSTGRESQL_BLUE_URL -a uuuo-metabase --confirm uuuo-metabase
-heroku pg:copy uuuo-web::HEROKU_POSTGRESQL_CHARCOAL_URL HEROKU_POSTGRESQL_BLUE_URL --app uuuo-metabase --confirm uuuo-metabase
+heroku pg:reset $TARGET -a uuuo-metabase --confirm uuuo-metabase
+heroku pg:copy $SOURCE $TARGET --app uuuo-metabase --confirm uuuo-metabase
 
 ## 成功はSlackに通知する。
 ## 通知頻度を指定：　現時刻が Heroku 環境変数（NOTIFY_WHEN_SUCCESS）の条件に合えば通知する。


### PR DESCRIPTION
###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

postgres DB readレプリカ作成[#911](https://github.com/uuuo-inc/uuuo-flutter/issues/911) にて作成したレプリカ（BLUE）へのコピーが 2022-08-23 18:30:39 頃から連続失敗する様になった。BLUEを諦め、AMBERを新設。それに伴いスクリプトを修正した。
- データベースの色URLを固定ではなく、heroku環境変数とした。
  - 2022/8/25現在以下のheroku環境変数key, valueとする。 
  - TARGET_POSTGRESQL_COLOR=HEROKU_POSTGRESQL_AMBER_URL
  - SOURCE_POSTGRESQL_COLOR=uuuo-web::HEROKU_POSTGRESQL_CHARCOAL_URL

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
